### PR TITLE
Corrected failing build args

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        - version: 3.0.9
+        - version=3.0.9
     ports:
       - "8002:8002"
     volumes:


### PR DESCRIPTION
The currenct build arg for valhalla was throwing an error due to wrong mapping:
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.valhalla.build.args contains {"version": "3.0.9"}, which is an invalid type, it should be a string
```
Either remove the space between the `:` and `3.0.9` or replace it with an `=`. 

**Solution:** I replaced it with `=` because the rest of the file already uses that mapping scheme.