### PR TITLE
Add prime server nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,28 +3,24 @@ MAINTAINER Julian Psotta <julian@gis-ops.com>
 
 # Set docker specific settings
 ENV TERM xterm
-RUN export DEBIAN_FRONTEND=noninteractive
 
 # Install deps
-RUN apt-get update && apt-get update --fix-missing
-
-# Install dependencies
-RUN apt-get install -y apt-utils dialog locales aptitude cmake build-essential autoconf pkg-config wget curl \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && apt-get update --fix-missing && \
+    apt-get install -y apt-utils dialog locales aptitude cmake build-essential autoconf pkg-config wget curl \
                         ca-certificates gnupg2 git parallel libczmq-dev libzmq5 spatialite-bin unzip libtool \
                         zlib1g-dev libsqlite3-mod-spatialite jq libgeos-dev libgeos++-dev libprotobuf-dev \
-                        protobuf-compiler libboost-all-dev libsqlite3-dev libspatialite-dev  liblua5.3-dev lua5.3
+                        protobuf-compiler libboost-all-dev libsqlite3-dev libspatialite-dev  liblua5.3-dev lua5.3 && \
+    locale-gen en_US.UTF-8 && \
+    # set paths to fix the libspatialite error
+    ln -s /usr/lib/x86_64-linux-gnu/mod_spatialite.so /usr/lib/mod_spatialite && \
+    # Create necessary folders
+    mkdir -p /valhalla/scripts /valhalla/conf/valhalla_tiles
 
 # Set locales
-RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-
-# set paths to fix the libspatialite error
-RUN ln -s /usr/lib/x86_64-linux-gnu/mod_spatialite.so /usr/lib/mod_spatialite
-
-# Create necessary folders
-RUN mkdir -p /valhalla/scripts /valhalla/conf/valhalla_tiles
 
 # Export path variables
 ENV SCRIPTS_DIR ${SCRIPTS_DIR:-"/valhalla/scripts"}
@@ -32,28 +28,16 @@ ENV CONFIG_PATH ${CONFIG_PATH:-"/valhalla/conf/valhalla.json"}
 
 WORKDIR /valhalla/
 
-# Copy build script
-COPY scripts/build_valhalla.sh ${SCRIPTS_DIR}
+# Copy all necessary build scripts
+COPY scripts/. ${SCRIPTS_DIR}
 
 # Build Valhalla
 ARG version
-RUN /bin/bash ${SCRIPTS_DIR}/build_valhalla.sh ${version}
-
-# Copy scripts for later use
-RUN cp -r /valhalla/valhalla_git/scripts/. ${SCRIPTS_DIR}
-COPY scripts/run.sh ${SCRIPTS_DIR}
-
-# Make the files accessible
-RUN chmod +x ${SCRIPTS_DIR}/run.sh
-
-# Delete build files
-RUN apt-get autoclean -y && rm -rf /valhalla/valhalla_git /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Change dirctory to the main script files
-WORKDIR /${SCRIPTS_DIR}
-
-# Add scripts for production use
-COPY scripts/configure_valhalla.sh ${SCRIPTS_DIR}
+RUN /bin/bash ${SCRIPTS_DIR}/build_valhalla.sh ${version} && \
+    # Copy scripts for later use
+    cp -r /valhalla/valhalla_git/scripts/. ${SCRIPTS_DIR} && \
+    chmod +x ${SCRIPTS_DIR}/run.sh && \
+    apt-get autoclean -y && rm -rf /valhalla/valhalla_git /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Expose the necessary port
 EXPOSE 8002

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,4 @@ RUN echo "Installing Valhalla..." && \
 
 # Expose the necessary port
 EXPOSE 8002
-ENTRYPOINT ["/bin/bash", "/valhalla/scripts/run.sh"]
-#CMD /valhalla/scripts/run.sh
+CMD ${SCRIPTS_DIR}/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,29 @@
-FROM gisops/prime_server-nodejs:latest-10.15.0
+FROM ubuntu:18.04
 MAINTAINER Julian Psotta <julian@gis-ops.com>
 
 # Set docker specific settings
 ENV TERM xterm
 
 # Install deps
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && apt-get update --fix-missing && \
-    apt-get install -y apt-utils dialog locales aptitude cmake build-essential autoconf pkg-config wget curl \
-                        ca-certificates gnupg2 git parallel libczmq-dev libzmq5 spatialite-bin unzip libtool \
-                        zlib1g-dev libsqlite3-mod-spatialite jq libgeos-dev libgeos++-dev libprotobuf-dev \
-                        protobuf-compiler libboost-all-dev libsqlite3-dev libspatialite-dev  liblua5.3-dev lua5.3 && \
+RUN echo "Installing dependencies..." && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update > /dev/null && apt-get update --fix-missing > /dev/null && \
+    apt-get install -y \
+        # prime_server requirements
+        automake locales autoconf pkg-config build-essential lcov libcurl4-openssl-dev git-core libzmq3-dev libczmq-dev \
+        # Valhalla requirements
+        apt-utils cmake curl wget jq \
+        ca-certificates gnupg2 parallel libczmq-dev libzmq5 spatialite-bin libtool \
+        zlib1g-dev libsqlite3-mod-spatialite libgeos-dev libgeos++-dev libprotobuf-dev \
+        protobuf-compiler libboost-all-dev libsqlite3-dev libspatialite-dev liblua5.3-dev lua5.3 \
+      > /dev/null && \
     locale-gen en_US.UTF-8 && \
     # set paths to fix the libspatialite error
     ln -s /usr/lib/x86_64-linux-gnu/mod_spatialite.so /usr/lib/mod_spatialite && \
     # Create necessary folders
     mkdir -p /valhalla/scripts /valhalla/conf/valhalla_tiles
 
-# Set locales
+# Set language
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
@@ -31,14 +37,19 @@ WORKDIR /valhalla/
 # Copy all necessary build scripts
 COPY scripts/. ${SCRIPTS_DIR}
 
+ARG PRIMESERVER_RELEASE=master
+RUN echo "Installing prime_server..." && \
+    /bin/bash ${SCRIPTS_DIR}/build_prime_server.sh ${PRIMESERVER_RELEASE}
+
 # Build Valhalla
-ARG version
-RUN /bin/bash ${SCRIPTS_DIR}/build_valhalla.sh ${version} && \
-    # Copy scripts for later use
+ARG VALHALLA_RELEASE=master
+RUN echo "Installing Valhalla..." && \
+    /bin/bash ${SCRIPTS_DIR}/build_valhalla.sh ${VALHALLA_RELEASE} && \
     cp -r /valhalla/valhalla_git/scripts/. ${SCRIPTS_DIR} && \
     chmod +x ${SCRIPTS_DIR}/run.sh && \
-    apt-get autoclean -y && rm -rf /valhalla/valhalla_git /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get autoclean -y && rm -rf /valhalla/prime_server /valhalla/valhalla_git /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Expose the necessary port
 EXPOSE 8002
 ENTRYPOINT ["/bin/bash", "/valhalla/scripts/run.sh"]
+#CMD /valhalla/scripts/run.sh

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -2,12 +2,13 @@ version: '3.0'
 services:
   valhalla:
     image: gisops/valhalla:latest
+    container_name: valhalla_latest
     build:
-      context: .
-      args:
-        - version=3.0.9
-    ports:
-      - "8002:8002"
+    #build:
+    #  context: .
+    #  args:
+    #    - VALHALLA_RELEASE=3.0.9
+    #    - PRIMESERVER_RELEASE=0.6.5
     volumes:
       - ./custom_files/:/custom_files
     environment:

--- a/scripts/build_prime_server.sh
+++ b/scripts/build_prime_server.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+url="https://github.com/kevinkreiser/prime_server.git"
+NPROC=$(nproc)
+
+git clone ${url} && cd prime_server
+git fetch && git fetch --tags && git checkout "${1}"
+git submodule update --init --recursive
+./autogen.sh
+./configure --prefix=/usr LIBS="-lpthread"
+make all -j"$NPROC"
+make -k test -j"$NPROC"
+make install

--- a/scripts/build_valhalla.sh
+++ b/scripts/build_valhalla.sh
@@ -9,14 +9,14 @@ git fetch --tags
 git checkout "${1}"
 git submodule sync
 git submodule update --init --recursive
-curl -o- curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+curl -o- curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 export NVM_DIR="$HOME/.nvm"
 [[ -s "$NVM_DIR/nvm.sh" ]] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-nvm install 10.15.0 && nvm use 10.15.0
+nvm install 12.16.1 && nvm use 12.16.1
 npm install --ignore-scripts --unsafe-perm=true
-ln -s ~/.nvm/versions/node/v10.15.0/include/node/node.h /usr/include/node.h
-ln -s ~/.nvm/versions/node/v10.15.0/include/node/uv.h /usr/include/uv.h
-ln -s ~/.nvm/versions/node/v10.15.0/include/node/v8.h /usr/include/v8.h
+ln -s ~/.nvm/versions/node/v12.16.1/include/node/node.h /usr/include/node.h
+ln -s ~/.nvm/versions/node/v12.16.1/include/node/uv.h /usr/include/uv.h
+ln -s ~/.nvm/versions/node/v12.16.1/include/node/v8.h /usr/include/v8.h
 mkdir build
 cmake -H. -Bbuild \
   -DCMAKE_C_FLAGS:STRING="${CFLAGS}" \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,7 +5,7 @@ CUSTOM_FILES="/custom_files"
 CONFIG_FILE="${CUSTOM_FILES}/valhalla.json"
 CUSTOM_CONFIG="${CUSTOM_FILES}/valhalla.json"
 
-sh /valhalla/scripts/configure_valhalla.sh ${SCRIPTS_PATH} ${CONFIG_FILE} ${CUSTOM_FILES} "${tile_urls}" "${min_x}" "${max_x}" "${min_y}" "${max_y}" "${build_elevation}" "${build_admins}" "${build_time_zones}" "${force_rebuild}" "${force_rebuild_elevation}" "${use_tiles_ignore_pbf}"
+/bin/bash /valhalla/scripts/configure_valhalla.sh ${SCRIPTS_PATH} ${CONFIG_FILE} ${CUSTOM_FILES} "${tile_urls}" "${min_x}" "${max_x}" "${min_y}" "${max_y}" "${build_elevation}" "${build_admins}" "${build_time_zones}" "${force_rebuild}" "${force_rebuild_elevation}" "${use_tiles_ignore_pbf}"
 
 if test -f ${CUSTOM_CONFIG}; then
   echo "Found config file. Starting valhalla service!"


### PR DESCRIPTION
Changes:
- base image: Ubuntu:18.04
- builds `prime_server` in this image (advantage being that we can version prime_server with each valhalla release)
- no more dependency on any other images
- merges several RUN and COPY commands

All in all that got the decompressed image size down to 1.28 GB, previously 2.13 GB. I tried a few base images, `debian:buster-slim` and its nodejs variant. They were all bigger, so seems ubuntu:18.04 was the best choice.