### PR TITLE
Fix tz build

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In the [Dockerhub repository](https://hub.docker.com/r/gisops/valhalla) you'll f
 For the following instructions to work, you'll need to have the image locally available already, either from [Docker Hub](https://hub.docker.com/repository/docker/gisops/valhalla) or from local. **Note**, when locally building the image, you'll need to set the `VALHALLA_RELEASE` build argument to be the same release as the branch you're building from this repository:
 
 ```bash
-docker build -t --build-arg VALHALLA_RELEASE=<release_matching_branch> gisops/valhalla .
+docker build -t gisops/valhalla --build-arg VALHALLA_RELEASE=<release_matching_branch> .
 #or
 docker pull gisops/valhalla:<tag>  # tag one of [latest, or Vahalla release version, e.g. 3.0.9]
 ```

--- a/scripts/configure_valhalla.sh
+++ b/scripts/configure_valhalla.sh
@@ -279,7 +279,7 @@ if [[ ${build_time_zones} == "True" ]]; then
   echo "==========================="
   echo "= Build the timezone data ="
   echo "==========================="
-  ./valhalla_build_timezones ${config_file}
+  ./valhalla_build_timezones > ${custom_tile_folder}/timezone_data/timezones.sqlite
 fi
 
 # Finally build the tiles


### PR DESCRIPTION
Starting from valhalla >= 3.0.9, tz file is streamed to stdout (by `valhalla_build_timezones`), and config file is no longer necessary in the command.

See https://github.com/valhalla/valhalla/issues/2118 and https://github.com/valhalla/valhalla/blob/master/docs/mjolnir/getting_started_guide.md

I also fixed the docker build command in the README