### PR TITLE
fix off-by-one error in hash counter

### DIFF
--- a/scripts/runtime/configure_valhalla.sh
+++ b/scripts/runtime/configure_valhalla.sh
@@ -33,7 +33,7 @@ hash_counter() {
   fi
 
   old_hashes=""
-  counter=-1
+  counter=0
   # Read the old hashes
   while IFS="" read -r line || [[ -n "$line" ]]; do
     echo "Scanning old hash ${line}"


### PR DESCRIPTION
.file_hashes.txt contains only hashes of specified pbf files, there's no reason to count one less hash.

Fixes #13.