### PR TITLE
curl follow redirects

### DIFF
--- a/scripts/runtime/configure_valhalla.sh
+++ b/scripts/runtime/configure_valhalla.sh
@@ -102,7 +102,7 @@ download_files() {
   download_counter=0
   for url in ${2}; do
     echo "URL: ${url}"
-    if curl --output /dev/null --silent --head --fail "${url}"; then
+    if curl --location --output /dev/null --silent --head --fail "${url}"; then
       echo ""
       echo "==============================================================="
       echo " Downloading  ${url}"


### PR DESCRIPTION
Mirrors like Geofabrik are working with redirects. To respect this, I added an option to `curl` which let's it follow redirects.

F.e. `https://download.geofabrik.de/europe-latest.osm.pbf` get's redirected to `http://ftp5.gwdg.de/pub/misc/openstreetmap/download.geofabrik.de/europe-latest.osm.pbf`.