### PR TITLE
only load elevation tiles covering the graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,14 @@ docker build -t gisops/valhalla .
 
 This image respects the following custom environment variables to be passed during container startup. Note, all variables have a default:
 
-- `tile_urls`: Add as many (space-separated) URLs as you like, e.g. https://download.geofabrik.de/europe/andorra-latest.osm.pbf http://download.geofabrik.de/europe/faroe-islands-latest.osm.pbf. Default `""`.
-- `min_x`: Minimum longitude for elevation tiles, in decimal WGS84, e.g. 18.5
-- `min_y`: Minimum latitude for elevation tiles, in decimal WGS84, e.g. 18.5
-- `max_x`: Maximum longitude for elevation tiles, in decimal WGS84, e.g. 18.5
-- `max_y`: Maximum latitude for elevation tiles, in decimal WGS84, e.g. 18.5
+- `tile_urls`: Add as many (space-separated) URLs as you like, e.g. https://download.geofabrik.de/europe/andorra-latest.osm.pbf 
 - `use_tiles_ignore_pbf`: `True` uses a local tile.tar file and skips building. Default `False`.
 - `force_rebuild`: `True` forces a rebuild of the routing tiles. Default `False`.
-- `build_elevation`: `True` downloads elevation tiles for the set bounding box. `Force` will do the same, but first delete any existing elevation tiles. Default `False`.
-- `build_admins`: `True` builds the admin db. `Force` will do the same, but first delete the existing db. Default `False`.
-- `build_time_zones`: `True` builds the timezone db. `Force` will do the same, but first delete the existing db. Default `False`.
-- `build_tar` (since 29.10.2021/v`3.1.5`): `True` creates a tarball of the tiles. `Force` will do the same, but first delete the existing tarball. Default `True`.
-- `server_threads`: How many threads `valhalla_service` will run with. Default is 1 thread less than the value of `nproc`.
+- `build_elevation`: `True` downloads elevation tiles which are covering the routing graph. `Force` will do the same, but first delete any existing elevation tiles. Default `False`.
+- `build_admins`: `True` builds the admin db needed for things like border-crossing penalties and detailed routing responses. `Force` will do the same, but first delete the existing db. Default `False`.
+- `build_time_zones`: `True` builds the timezone db which is needed for time-dependent routing. `Force` will do the same, but first delete the existing db. Default `False`.
+- `build_tar` (since 29.10.2021/v`3.1.5`): `True` creates a tarball of the tiles including an index which allows for extremely faster graph loading after reboots. `Force` will do the same, but first delete the existing tarball. Default `True`.
+- `server_threads`: How many threads `valhalla_service` will run with. Default is the value of `nproc`.
 
 ## Container recipes
 

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -15,14 +15,9 @@ services:
     environment:
       # Auto-download PBFs from Geofabrik
       #- tile_urls=https://download.geofabrik.de/europe/andorra-latest.osm.pbf https://download.geofabrik.de/europe/albania-latest.osm.pbf
-      # Get correct bounding box from e.g. https://boundingbox.klokantech.com/
-      #- min_x=18 # -> Albania | -180 -> World
-      #- min_y=38 # -> Albania | -90  -> World
-      #- max_x=22 # -> Albania |  180 -> World
-      #- max_y=43 # -> Albania |  90  -> World
-      - server_threads=2  # determines how many threads will be used to run valhalla
+      - server_threads=2  # determines how many threads will be used to run the valhalla server
       - use_tiles_ignore_pbf=True  # load existing valhalla_tiles.tar directly
-      - build_elevation=False  # build elevation with "True" or "Force", needs valid coordinates min_x, min_y etc
+      - build_elevation=False  # build elevation with "True" or "Force": will download only the elevation for areas covered by the graph tiles
       - build_admins=False  # build admins db with "True" or "Force"
       - build_time_zones=False  # build timezone db with "True" or "Force"
       - build_tar=True  # build an indexed tar file from the tile_dir for faster graph loading times

--- a/scripts/runtime/configure_valhalla.sh
+++ b/scripts/runtime/configure_valhalla.sh
@@ -242,7 +242,7 @@ build_dbs
 
 # Finally build the tiles
 if [[ ${build_elevation} == "True" || ${build_elevation} == "Force" ]]; then
-  if [[ ${build_elevation} == "Force" && test -d $elevation_path ]]; then
+  if [[ ${build_elevation} == "Force" && -d $elevation_path ]]; then
     echo "Rebuilding elevation tiles"
     rm -rf $elevation_path
   fi
@@ -261,13 +261,13 @@ if [[ ${build_elevation} == "True" || ${build_elevation} == "Force" ]]; then
   echo "================================="
   echo "= Download the elevation tiles ="
   echo "================================="
-  valhalla_build_elevation -b ${min_x},${min_y},${max_x},${max_y} -c $config_file || exit 1
+  valhalla_build_elevation --from-tiles --decompress -c $config_file || exit 1
 
   echo ""
   echo "======================================"
   echo "= Enhancing the graph with elevation ="
   echo "======================================"
-  valhalla_build_tiles 
+  valhalla_build_tiles -c ${config_file} -s enhance ${files} || exit 1
 else
   echo ""
   echo "========================="
@@ -275,7 +275,7 @@ else
   echo "========================="
   echo "Running build tiles with: ${config_file} ${files}"
 
-  valhalla_build_tiles -c ${config_file} -s enhance ${files} || exit 1
+  valhalla_build_tiles -c ${config_file} ${files} || exit 1
 fi
 
 echo "Successfully built files: ${files}"

--- a/scripts/runtime/configure_valhalla.sh
+++ b/scripts/runtime/configure_valhalla.sh
@@ -113,7 +113,7 @@ build_config () {
   fi
 }
 
-build_extras () {
+build_dbs () {
   # Only build the dbs if forced or the files don't exist
 
   if [[ ${build_admins} == "True" && ! -f $admin_db ]] || [[ ${build_admins} == "Force" ]]; then
@@ -137,21 +137,6 @@ build_extras () {
     valhalla_build_timezones > ${timezone_db}
   else
     echo "=========================="
-  fi
-
-
-  if [[ ${build_elevation} == "True" || ${build_elevation} == "Force" ]]; then
-    if [[ ${force_rebuild_elevation} == "Force" ]]; then
-      echo "Rebuilding elevation tiles"
-      rm -rf $elevation_path
-      mkdir -p $elevation_path
-    fi
-    # Build the elevation data
-    echo ""
-    echo "==========================="
-    echo "= Download the elevation tiles ="
-    echo "==========================="
-    valhalla_build_elevation -b ${min_x},${min_y},${max_x},${max_y} -c $config_file
   fi
 }
 
@@ -179,7 +164,7 @@ if test -f "${tile_extract}" || test -d "${tile_dir}"; then
   if [[ ${use_tiles_ignore_pbf} == "True" ]]; then
     echo "Jumping directly to the tile loading!"
     build_config
-    build_extras
+    build_dbs
     exit 0
   fi
 else
@@ -215,7 +200,7 @@ if test -f "${tile_extract}" || test -d "${tile_dir}"; then
     echo "PBF file Counter: $files_counter"
     echo "Found valhalla tiles!"
     build_config
-    build_extras
+    build_dbs
     exit 0
   else
     echo "New files were detected, rebuilding files: ${files}"
@@ -253,15 +238,45 @@ if [[ ${files_counter} == 0 ]]; then
 fi
 
 build_config
-build_extras
+build_dbs
 
 # Finally build the tiles
-echo ""
-echo "========================="
-echo "= Build the tile files. ="
-echo "========================="
-echo "Running build tiles with: ${config_file} ${files}"
-valhalla_build_tiles -c ${config_file} ${files}	|| exit 1
+if [[ ${build_elevation} == "True" || ${build_elevation} == "Force" ]]; then
+  if [[ ${build_elevation} == "Force" && test -d $elevation_path ]]; then
+    echo "Rebuilding elevation tiles"
+    rm -rf $elevation_path
+  fi
+
+  # if we should build with elevation we need to build the tiles in stages
+
+  echo ""
+  echo "========================="
+  echo "= Build the initial graph. ="
+  echo "========================="
+
+  valhalla_build_tiles -c ${config_file} -e build ${files} || exit 1
+
+  # Build the elevation data
+  echo ""
+  echo "================================="
+  echo "= Download the elevation tiles ="
+  echo "================================="
+  valhalla_build_elevation -b ${min_x},${min_y},${max_x},${max_y} -c $config_file || exit 1
+
+  echo ""
+  echo "======================================"
+  echo "= Enhancing the graph with elevation ="
+  echo "======================================"
+  valhalla_build_tiles 
+else
+  echo ""
+  echo "========================="
+  echo "= Build the tile files. ="
+  echo "========================="
+  echo "Running build tiles with: ${config_file} ${files}"
+
+  valhalla_build_tiles -c ${config_file} -s enhance ${files} || exit 1
+fi
 
 echo "Successfully built files: ${files}"
 add_hashes "${files}"

--- a/scripts/runtime/run.sh
+++ b/scripts/runtime/run.sh
@@ -7,7 +7,7 @@ CONFIG_FILE="${CUSTOM_FILES}/valhalla.json"
 TILE_DIR="${CUSTOM_FILES}/valhalla_tiles"
 TILE_TAR="${CUSTOM_FILES}/valhalla_tiles.tar"
 
-build_tar() {
+do_build_tar() {
 
   if ! test -d $TILE_DIR; then
     echo "No tiles found. Did you forget to build tiles?"
@@ -32,7 +32,7 @@ else
     echo "========================================================================="
     echo "= No valid bounding box or elevation parameter set. Skipping elevation! ="
     echo "========================================================================="
-    build_elevation="False"
+    build_elevation="True"
   fi
 fi
 
@@ -63,7 +63,7 @@ if [[ $1 == "build_tiles" ]]; then
   /bin/bash /valhalla/scripts/configure_valhalla.sh ${CONFIG_FILE} ${CUSTOM_FILES} ${TILE_DIR} ${TILE_TAR}
   # tar tiles unless not wanted
   if [[ "$build_tar" == "True" ]]; then
-    build_tar
+    do_build_tar
   else
     echo "Skipping tar building. Expect degraded performance while using Valhalla."
   fi
@@ -78,7 +78,7 @@ if [[ $1 == "build_tiles" ]]; then
   # Keep docker running easy
   exec "$@"
 elif [[ $1 == "tar_tiles" ]]; then
-  build_tar
+  do_build_tar
 else
   echo "Unrecognized CMD: '$1'"
   exit 1

--- a/scripts/runtime/run.sh
+++ b/scripts/runtime/run.sh
@@ -53,7 +53,7 @@ if [[ -z "$use_tiles_ignore_pbf" ]]; then
 fi
 
 if [[ -z "$server_threads" ]]; then
-  server_threads=$(expr $(nproc) - 1)
+  server_threads=$(nproc)
 fi
 
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -49,7 +49,7 @@ cp ${ANDORRA} ${custom_file_folder}
 
 #### FULL BUILD ####
 echo "#### Full build test, no extract ####"
-docker run -d --name valhalla_full -p 8002:8002 -v $custom_file_folder:/custom_files -e use_tiles_ignore_pbf=False -e build_elevation=True -e build_admins=True -e build_time_zones=True -e min_x=1.409683 -e min_y=42.423963 -e max_x=1.799011 -e max_y=42.661736 -e build_tar=False gisops/valhalla:latest
+docker run -d --name valhalla_full -p 8002:8002 -v $custom_file_folder:/custom_files -e use_tiles_ignore_pbf=False -e build_elevation=True -e build_admins=True -e build_time_zones=True -e build_tar=False gisops/valhalla:latest
 wait_for_docker
 
 # Make sure all files are there!


### PR DESCRIPTION
fixes #40 

implements https://github.com/valhalla/valhalla/pull/3318 to only download elevation tiles which are covering the graph tiles. this meant we had to switch to a build process in stages, where we first build the base graph, then download the elevation tiles based on that and finally run the other stages to enhance the graph.

[reportedly](https://github.com/valhalla/valhalla/pull/3318#issuecomment-934331683) that reduces the disk space for the full planet by approx a **terabyte**!