### PR TITLE
Improve diagnostics for downloading

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -67,7 +67,7 @@ add_hashes() {
 }
 
 download_file() {
-  if curl --location --output /dev/null --silent --head --fail "${1}"; then
+  if curl --location --output /dev/null --silent --show-error --head --fail "${1}"; then
     echo ""
     echo "==============================================================="
     echo " Downloading  ${url}"


### PR DESCRIPTION
Before, if downloading failed, there would be no clue as to why.  The `--show-error` flag was built to be work with the `--silent` flag. Here are the docs for it:

> Use -S, --show-error in addition to [--silent] to disable progress meter but still show error messages.

In the interest of creating a smaller image, consider using `wget` instead as `wget` is installed by default on Ubuntu