### PR TITLE
Add valhalla-python integration + smoke tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,7 @@ WORKDIR /custom_files
 RUN    python3 -c "import valhalla,sys; print (sys.version, valhalla)" \
     && valhalla_build_config | jq type \
     && valhalla_build_tiles -v \
-    && cat /usr/local/src/valhalla_version \
-    && ls -la /usr/local/bin/valhalla*
+    && cat /usr/local/src/valhalla_version
 
 # Expose the necessary port
 EXPOSE 8002

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ WORKDIR /custom_files
 # Smoke tests
 RUN    python3 -c "import valhalla,sys; print (sys.version, valhalla)" \
     && valhalla_build_config | jq type \
+    && cat /usr/local/src/valhalla_version \
     && valhalla_build_tiles -v \
     && ls -la /usr/local/bin/valhalla*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ WORKDIR /custom_files
 RUN    python3 -c "import valhalla,sys; print (sys.version, valhalla)" \
     && valhalla_build_config | jq type \
     && valhalla_build_tiles -v \
-    && cat /usr/local/src/valhalla_version
+    && ls -la /usr/local/bin/valhalla*
 
 # Expose the necessary port
 EXPOSE 8002

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update > /dev/null && \
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /usr/bin/prime_* /usr/bin/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libprime* /usr/lib/x86_64-linux-gnu/
-  
+COPY --from=builder /usr/lib/python3/dist-packages/valhalla/* /usr/lib/python3/dist-packages/valhalla/
+
 ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
 # export the True defaults
 ENV use_tiles_ignore_pbf=True
@@ -55,6 +56,13 @@ COPY scripts/. /valhalla/scripts
 USER valhalla
 
 WORKDIR /custom_files
+
+# Smoke tests
+RUN    python3 -c "import valhalla,sys; print (sys.version, valhalla)" \
+    && valhalla_build_config | jq type \
+    && valhalla_build_tiles -v \
+    && cat /usr/local/src/valhalla_version \
+    && ls -la /usr/local/bin/valhalla*
 
 # Expose the necessary port
 EXPOSE 8002


### PR DESCRIPTION
Proposal :
*  similar python-integration changes as in the  upstream 
     *  https://github.com/valhalla/valhalla/issues/3484
*  smoke tests


Expected smoke test log
```bash
 ---> Running in 84c2435cfdd0
3.8.10 (default, Nov 26 2021, 20:14:08) 
[GCC 9.3.0] <module 'valhalla' from '/usr/lib/python3/dist-packages/valhalla/__init__.py'>
"object"
valhalla_build_tiles 3.1.4
https://github.com/valhalla/valhalla/tree/c34fd8f40895add4574a79cbc95ec601e8063345
-rwxr-xr-x 1 root root 4207312 Jan  5 03:10 /usr/local/bin/valhalla_build_admins
-rwxr-xr-x 1 root root   27935 Jan  5 02:21 /usr/local/bin/valhalla_build_config
-rwxr-xr-x 1 root root    8034 Jan  5 02:21 /usr/local/bin/valhalla_build_elevation
-rwxr-xr-x 1 root root    7345 Jan  5 02:21 /usr/local/bin/valhalla_build_extract
-rwxr-xr-x 1 root root 4117200 Jan  5 03:10 /usr/local/bin/valhalla_build_tiles
-rwxr-xr-x 1 root root    7981 Jan  5 02:21 /usr/local/bin/valhalla_build_timezones
-rwxr-xr-x 1 root root 7817232 Jan  5 03:10 /usr/local/bin/valhalla_service
-rwxr-xr-x 1 root root 1887888 Jan  5 03:10 /usr/local/bin/valhalla_ways_to_edges
```