### PR TITLE
Make serving of tiles optional in build action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
 # export the True defaults
 ENV use_tiles_ignore_pbf=True
 ENV build_tar=True
+ENV serve_tiles=True
 
 # what this does:
 # if the docker user specified a UID/GID (other than 0, would be a ludicrous instruction anyways) in the image build, we will use that to create the valhalla linux user in the image. that ensures that the docker user can edit the created files on the host without sudo and with 664/775 permissions, so that users of that group can also write. the default is to give the valhalla user passwordless sudo. that also means that all commands creating files in the entrypoint script need to be executed with sudo when built with defaults..

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This image respects the following custom environment variables to be passed duri
 - `build_tar` (since 29.10.2021/v`3.1.5`): `True` creates a tarball of the tiles including an index which allows for extremely faster graph loading after reboots. `Force` will do the same, but first delete the existing tarball. Default `True`.
 - `server_threads`: How many threads `valhalla_service` will run with. Default is the value of `nproc`.
 - `path_extension`: This path will be appended to the container-internal `/custom_files` (and by extension to the docker volume mapped to that path) and will be the directory where all files will be created. Can be very useful in certain deployment scenarios. No leading/trailing path separator allowed. Default is ''.
+- `serve_tiles`: `True` starts the valhalla service. Default `True`.
 
 ## Container recipes
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -40,6 +40,9 @@ fi
 if [[ -z $build_tar ]]; then
   build_tar="True"
 fi
+if [[ -z $serve_tiles ]]; then
+  serve_tiles="True"
+fi
 
 # evaluate CMD
 if [[ $1 == "build_tiles" ]]; then
@@ -63,16 +66,19 @@ if [[ $1 == "build_tiles" ]]; then
     find "${CUSTOM_FILES}" -type f -exec chmod 664 {} \;
   fi
 
-  if test -f ${CONFIG_FILE}; then
-    echo "INFO: Found config file. Starting valhalla service!"
-    run_cmd "valhalla_service ${CONFIG_FILE} ${server_threads}"
+  if [[ ${serve_tiles} == "True" ]]; then
+    if test -f ${CONFIG_FILE}; then
+      echo "INFO: Found config file. Starting valhalla service!"
+      run_cmd "valhalla_service ${CONFIG_FILE} ${server_threads}"
+    else
+      echo "WARNING: No config found!"
+    fi
+
+    # Keep docker running easy
+    exec "$@"
   else
-    echo "WARNING: No config found!"
+    echo "INFO: Not serving tiles. Exiting."
   fi
-
-  # Keep docker running easy
-  exec "$@"
-
 elif [[ $1 == "tar_tiles" ]]; then
   do_build_tar
 else


### PR DESCRIPTION
Great repo! This just adds an option to `build_tiles` without **serving** the app via a `serve_tiles` Environment variable.  Feel free to close if you'd prefer to not utilize this change.  Thanks in advance for the support!