### PR TITLE
add ability to change the file/dir name of the graph on disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker build -t gisops/valhalla .
 
 This image respects the following custom environment variables to be passed during container startup. Note, all variables have a default:
 
-- `tile_urls`: Add as many (space-separated) URLs as you like, e.g. https://download.geofabrik.de/europe/andorra-latest.osm.pbf 
+- `tile_urls`: Add as many (space-separated) URLs as you like, e.g. https://download.geofabrik.de/europe/andorra-latest.osm.pbf
 - `use_tiles_ignore_pbf`: `True` uses a local tile.tar file and skips building. Default `False`.
 - `force_rebuild`: `True` forces a rebuild of the routing tiles. Default `False`.
 - `build_elevation`: `True` downloads elevation tiles which are covering the routing graph. `Force` will do the same, but first delete any existing elevation tiles. Default `False`.
@@ -64,6 +64,7 @@ This image respects the following custom environment variables to be passed duri
 - `server_threads`: How many threads `valhalla_service` will run with. Default is the value of `nproc`.
 - `path_extension`: This path will be appended to the container-internal `/custom_files` (and by extension to the docker volume mapped to that path) and will be the directory where all files will be created. Can be very useful in certain deployment scenarios. No leading/trailing path separator allowed. Default is ''.
 - `serve_tiles`: `True` starts the valhalla service. Default `True`.
+- `tileset_name`: The name of the resulting graph on disk. Very useful in case you want to build multiple datasets in the same directory. Default `valhalla_tiles`.
 
 ## Container recipes
 

--- a/scripts/configure_valhalla.sh
+++ b/scripts/configure_valhalla.sh
@@ -52,23 +52,23 @@ done
 do_build="False"
 if ! test -f "${TILE_TAR}" && ! [ -n "$(ls -A ${TILE_DIR} 2>/dev/null)" ]; then
   # build if no tiles exist
-  echo "WARNING: No routing tiles found, starting new build.."
+  echo "WARNING: No routing tiles found at ${TILE_TAR} or ${TILE_DIR}, starting new build.."
   do_build="True"
-elif [[ "${force_rebuild}" == "True" ]]; then
+elif [[ ${force_rebuild} == "True" ]]; then
   # respect the env var
-  echo "WARNING: force_rebuild True."
+  echo "WARNING: force_rebuild ${force_rebuild}."
   do_build="True"
 elif [[ "${do_admins}" == "True" ]]; then
   # rebuild if the admin db has to be built
-  echo "WARNING: No admin db found, starting a new build"
+  echo "WARNING: Requested admin db, but none found, starting a new build"
   do_build="True"
 elif [[ "${do_timezones}" == "True" ]]; then
   # rebuild if the timezone db has to be built
-  echo "WARNING: No timezone db found, starting a new build"
+  echo "WARNING: Requested timezone db, but none found, starting a new build"
   do_build="True"
 elif [[ "${do_elevation}" == "True" ]] && ! [ -n "$(ls -A ${ELEVATION_PATH} 2>/dev/null)" ]; then
   # build if elevation was requested but not downloaded yet
-  echo "WARNING: No elevation tiles found, starting a new build"
+  echo "WARNING: Requested elevation support, but none found, starting a new build"
   do_build="True"
 elif [[ "${use_tiles_ignore_pbf}" == "True" ]]; then
   # don't build if there are tiles and we want to load them

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -11,8 +11,8 @@ if ! test -d "${CUSTOM_FILES}"; then
 fi
 
 CONFIG_FILE="${CUSTOM_FILES}/valhalla.json"
-TILE_DIR="${CUSTOM_FILES}/valhalla_tiles"
-TILE_TAR="${CUSTOM_FILES}/valhalla_tiles.tar"
+TILE_DIR="${CUSTOM_FILES}/${tileset_name:-valhalla_tiles}"
+TILE_TAR="${CUSTOM_FILES}/${tileset_name:-valhalla_tiles}.tar"
 HASH_FILE="${CUSTOM_FILES}/file_hashes.txt"
 ADMIN_DB="${CUSTOM_FILES}/admin_data/admins.sqlite"
 TIMEZONE_DB="${CUSTOM_FILES}/timezone_data/timezones.sqlite"


### PR DESCRIPTION
so far it's always `valhalla_tiles.tar` which is zero descriptive. this pr adds a new env var `tileset_name` defaulting to `valhalla_tiles.tar` (so should be easily backwards-compatible).