### PR TITLE
fixed a bug which caused build_elevation not working properly

### DIFF
--- a/scripts/configure_valhalla.sh
+++ b/scripts/configure_valhalla.sh
@@ -24,7 +24,7 @@ fi
 do_elevation="False"
 do_admins="False"
 do_timezones="False"
-if [[ "${build_elevation}" == "True" ]] || [[ "${build_elevation}" == "Force" ]] || ! ([[ -z "${min_x}" ]] && [[ -z "${min_y}" ]] && [[ -z "${max_x}" ]] && [[ -z "${max_y}" ]]); then
+if ([[ "${build_elevation}" == "True" ]] || [[ "${build_elevation}" == "Force" ]]) && ! ([[ -z "${min_x}" ]] || [[ -z "${min_y}" ]] || [[ -z "${max_x}" ]] || [[ -z "${max_y}" ]]); then
   do_elevation="True"
 fi
 if ([[ "${build_admins}" == "True" ]] && ! test -f "${ADMIN_DB}") || [[ "${build_admins}" == "Force" ]]; then


### PR DESCRIPTION
It seems that line 27 in configure_valhalla.sh sets the do_elevation variable to be "True" whenever all values of max_x, min_x, max_y and min_y are defined. Now it's been corrected in a way that do_elevation will be set to True if and only if all 4 values of mentioned variables are set and build_elevation was set to True or Force