### PR TITLE
fix a small bug with configuring transit and add traffic.tar if specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This image respects the following custom environment variables to be passed duri
 - `path_extension`: This path will be appended to the container-internal `/custom_files` (and by extension to the docker volume mapped to that path) and will be the directory where all files will be created. Can be very useful in certain deployment scenarios. No leading/trailing path separator allowed. Default is ''.
 - `serve_tiles`: `True` starts the valhalla service. Default `True`.
 - `tileset_name`: The name of the resulting graph on disk. Very useful in case you want to build multiple datasets in the same directory. Default `valhalla_tiles`.
+- `traffic_name`: The name of the traffic.tar. Again, useful for serving mulitple traffic archives from the same directory. If empty, i.e. "", then no traffic archive will be built. Default `traffic.tar`.
 
 ## Container recipes
 

--- a/scripts/configure_valhalla.sh
+++ b/scripts/configure_valhalla.sh
@@ -123,13 +123,15 @@ if test -f "${CONFIG_FILE}"; then
   jq --arg d "${ELEVATION_PATH}" '.additional_data.elevation = $d' "${CONFIG_FILE}"| sponge "${CONFIG_FILE}"
   jq --arg d "${GTFS_DIR}" '.mjolnir.transit_feeds_dir = $d' "${CONFIG_FILE}"| sponge "${CONFIG_FILE}"
   jq --arg d "${TRANSIT_DIR}" '.mjolnir.transit_dir = $d' "${CONFIG_FILE}"| sponge "${CONFIG_FILE}"
+  jq --arg d "${TRAFFIC_TAR}" '.mjolnir.traffic_extract = $d' "${CONFIG_FILE}"| sponge "${CONFIG_FILE}"
 else
   additional_data_elevation="--additional-data-elevation $ELEVATION_PATH"
   mjolnir_admin="--mjolnir-admin ${ADMIN_DB}"
   mjolnir_timezone="--mjolnir-timezone ${TIMEZONE_DB}"
   transit_dir="--mjolnir-transit-dir ${TRANSIT_DIR}"
   gtfs_dir="--mjolnir-transit_feeds_dir ${GTFS_DIR}"
-  valhalla_build_config --mjolnir-tile-dir ${TILE_DIR} --mjolnir-tile-extract ${TILE_TAR} ${transit_dir} ${mjolnir_timezone} ${mjolnir_admin} ${additional_data_elevation} --mjolnir-traffic-extract "" --mjolnir-transit-dir "" > ${CONFIG_FILE}  || exit 1
+  traffic="--mjolnir-traffic-extract ${traffic_extract}"
+  valhalla_build_config --mjolnir-tile-dir ${TILE_DIR} --mjolnir-tile-extract ${TILE_TAR} ${transit_dir} ${mjolnir_timezone} ${mjolnir_admin} ${additional_data_elevation} ${traffic} > ${CONFIG_FILE}  || exit 1
 fi
 
 # build the databases maybe

--- a/scripts/configure_valhalla.sh
+++ b/scripts/configure_valhalla.sh
@@ -130,7 +130,7 @@ else
   mjolnir_timezone="--mjolnir-timezone ${TIMEZONE_DB}"
   transit_dir="--mjolnir-transit-dir ${TRANSIT_DIR}"
   gtfs_dir="--mjolnir-transit_feeds_dir ${GTFS_DIR}"
-  traffic="--mjolnir-traffic-extract ${traffic_extract}"
+  traffic="--mjolnir-traffic-extract ${TRAFFIC_TAR}"
   valhalla_build_config --mjolnir-tile-dir ${TILE_DIR} --mjolnir-tile-extract ${TILE_TAR} ${transit_dir} ${mjolnir_timezone} ${mjolnir_admin} ${additional_data_elevation} ${traffic} > ${CONFIG_FILE}  || exit 1
 fi
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -19,6 +19,7 @@ ADMIN_DB="${CUSTOM_FILES}/admin_data/admins.sqlite"
 TIMEZONE_DB="${CUSTOM_FILES}/timezone_data/timezones.sqlite"
 ELEVATION_PATH="${CUSTOM_FILES}/elevation_data"
 TRANSIT_DIR="${CUSTOM_FILES}/transit_tiles"
+TRAFFIC_TAR="${CUSTOM_FILES}/${traffic_name:-traffic}.tar"
 
 maybe_create_dir() {
   if ! test -d $1; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -18,7 +18,11 @@ run_cmd() {
 
 do_build_tar() {
   if ([[ ${build_tar} == "True" && ! -f $TILE_TAR ]]) || [[ ${build_tar} == "Force" ]]; then
-    run_cmd "valhalla_build_extract -c ${CONFIG_FILE} -v"
+    options="-c ${CONFIG_FILE} -v"
+    if ! [[ -z ${traffic_name} ]]; then
+      options="${options} -t"
+    fi
+    run_cmd "valhalla_build_extract ${options}"
   fi
 }
 


### PR DESCRIPTION
transit dir config was overwriting itself with `""`. also added traffic.tar when building an extract, doesn't hurt.