### PR TITLE
fix signals being ignored (#113)

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -10,9 +10,9 @@ run_cmd() {
   if [[ $(id --user) == "59999" ]] && [[ $(id --group) == "59999" ]]; then
     # -E preserves the env vars, but some are still nulled for security reasons
     # use "env" to preserve them
-    sudo -E env LD_LIBRARY_PATH=$LD_LIBRARY_PATH $1 || exit 1
+    $cmd_prefix sudo -E env LD_LIBRARY_PATH=$LD_LIBRARY_PATH $1 || exit 1
   else
-    $1 || exit 1
+    $cmd_prefix $1 || exit 1
   fi
 }
 
@@ -75,7 +75,7 @@ if [[ $1 == "build_tiles" ]]; then
   if [[ ${serve_tiles} == "True" ]]; then
     if test -f ${CONFIG_FILE}; then
       echo "INFO: Found config file. Starting valhalla service!"
-      run_cmd "valhalla_service ${CONFIG_FILE} ${server_threads}"
+      cmd_prefix=exec run_cmd "valhalla_service ${CONFIG_FILE} ${server_threads}"
     else
       echo "WARNING: No config found!"
     fi


### PR DESCRIPTION
Previously when running the Valhalla service with e.g.:

    $ docker run -v $PWD/data:/data ghcr.io/gis-ops/docker-valhalla/valhalla
    ...
    INFO: Found config file. Starting valhalla service!
    ....

You couldn't stop it with Ctrl+C (SIGINT) or `kill $!` (SIGTERM) when run in the background, because the run.sh shell script didn't use `exec` for the `valhalla_service` command, which resulted in an intermediary shell process (that didn't pass the signals to child processes because Docker gives it PID 1, which is special[1]).  This is a well-known pitfall of Docker ENTRYPOINT shell scripts.[2][3]

This commit fixes that oversight.

Sidenote: It still takes ~30 seconds for a SIGTERM to shutdown the server because valhalla_service has configured such a graceful shutdown period for the prime_server HTTP server.

[1]: https://docs.docker.com/engine/reference/builder/#entrypoint
[2]: https://hynek.me/articles/docker-signals/
[3]: https://petermalmgren.com/signal-handling-docker/